### PR TITLE
Fix for "Cannot read property 'length' of undefined" on .optimize()

### DIFF
--- a/lib/annotate-directive.js
+++ b/lib/annotate-directive.js
@@ -144,7 +144,7 @@
                     if (isDirective(stmt)) {
                         stmt.type = Syntax.DirectiveStatement;
                         if (stmt.expression.raw) {
-                            stmt.directive = stmt.expression.raw.substring(1, stmt.raw.length - 1);
+                            stmt.directive = stmt.expression.raw.substring(1, stmt.expression.raw.length - 1);
                             stmt.value = stmt.expression.value;
                             stmt.raw = stmt.expression.raw;
                         } else {


### PR DESCRIPTION
Possibly correcting what might have been an accidental omission of one chain in the property lookup.
