### PR TITLE
support static evaluation of logical operators (&&, ||)

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -103,6 +103,10 @@
 
     function doBinary(operator, left, right) {
         switch (operator) {
+        case '||':
+            return left || right;
+        case '&&':
+            return left && right;
         case '|':
             return left | right;
         case '^':


### PR DESCRIPTION
I don't have a test case for this yet because I actually couldn't reproduce the issue I was running into. But I was getting the error `Unreachable point. logically broken.`, and I traced it back to these missing operators.
