### PR TITLE
Cleanup: consistently use common.unreachable();

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -78,7 +78,10 @@
         if (operator === '||') {
             return left || right;
         }
-        return left && right;
+        if (operator === '&&') {
+            return left && right;
+        }
+        common.unreachable();
     }
 
     function doUnary(operator, argument) {
@@ -99,6 +102,7 @@
         case 'typeof':
             return typeof argument;
         }
+        common.unreachable();
     }
 
     function doBinary(operator, left, right) {


### PR DESCRIPTION
Just a minor cleanup - common.unreachable() was missing from some places in evaluator.js, eg. doUnary() had an implicit undefined return if the operator was not found (that would never happen with the current code... but just to make it consistent, or in case ES gets more operators in the future ;)
