### PR TITLE
Temporarily use escodegen 1.6.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "camel-case": "^1.1.2",
-    "escodegen": "^1.6.1",
+    "escodegen": "~1.6.1",
     "escope": "~2.0.6",
     "esprima": "^2.0.0",
     "esshorten": "~1.1.0",


### PR DESCRIPTION
Until https://github.com/estools/escodegen/issues/256 is fixed, running esmangle tests (from its git master branch), including in a CI environment (see e.g. https://github.com/jquery/esprima/issues/1321) will install the latest escodegen 1.7.0 and thus `test/compare/escapeless.js` would fail. Locking down the dependency to just escodegen 1.6.x temporarily solves the problem.