### PR TITLE
Use the new `license` field in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,7 @@
     "q": "^1.2.0",
     "xyz": "^0.5.0"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/estools/esmangle/raw/master/LICENSE.BSD"
-    }
-  ],
+  "license": "BSD-2-Clause",
   "scripts": {
     "test": "grunt travis",
     "lint": "grunt lint",


### PR DESCRIPTION
This will silence npm warning of "No license field".

The project license can be specified using SPDX license id (see
https://spdx.org/licenses/). The old `licenses` array is deprecated,
per https://docs.npmjs.com/files/package.json#license.